### PR TITLE
Fix floats representation as int

### DIFF
--- a/insane.go
+++ b/insane.go
@@ -1537,7 +1537,7 @@ func (n *Node) AsInt() int {
 	case hellBitField:
 		fallthrough
 	case hellBitNumber:
-		if strings.IndexByte(n.data, '.') != -1 {
+		if strings.IndexAny(n.data, ".eE") != -1 {
 			return int(math.Round(decodeFloat64(n.data)))
 		} else {
 			return int(decodeInt64(n.data))

--- a/insane_test.go
+++ b/insane_test.go
@@ -136,7 +136,7 @@ func TestDecodeTrueFalseNull(t *testing.T) {
 }
 
 func TestDecodeNumber(t *testing.T) {
-	json := `{"first": 100,"second": 1e20}`
+	json := `{"first": 100,"second": 1e20,"third": 1e+1}`
 	root, err := DecodeString(json)
 	defer Release(root)
 
@@ -145,6 +145,7 @@ func TestDecodeNumber(t *testing.T) {
 
 	assert.Equal(t, 100, root.Dig("first").AsInt(), "wrong node value")
 	assert.Equal(t, 1e20, root.Dig("second").AsFloat(), "wrong node value")
+	assert.Equal(t, 10, root.Dig("third").AsInt(), "wrong node value")
 }
 
 func TestDecodeErr(t *testing.T) {


### PR DESCRIPTION
https://play.golang.org/p/l55RaWCbfUP

If json is `{"value": 1e+1}`, then `AsInt()` should be 10 instead of 0